### PR TITLE
Debug and add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    name: Wheels (Python ${{ matrix.python-version }} / ${{ matrix.runs-on }})
+    name: Wheels (Python ${{ matrix.python-version }} / Go ${{ matrix.go-version }} / ${{ matrix.runs-on }})
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,27 +49,11 @@ jobs:
         run: choco install mingw
 
       - name: Install Python dependencies
-        run: python -m pip install build virtualenv
+        run: python -m pip install build virtualenv nox
 
       - name: Build binary distribution (wheel)
         run: |
           python -m build --wheel . --outdir dist/
 
-      - name: Test entry points for package for macOS and Linux
-        if: matrix.runs-on != 'windows-latest'
-        run: |
-          python -m virtualenv venv
-          source venv/bin/activate
-          python -m pip install dist/*.whl
-          hugo version
-          hugo env --logLevel debug
-
-      - name: Test entry points for package for Windows
-        if: matrix.runs-on == 'windows-latest'
-        shell: bash
-        run: |
-          python -m virtualenv venv
-          venv\Scripts\activate
-          python -m pip install dist\*.whl
-          hugo version
-          hugo env --logLevel debug
+      - name: Test entry points for package
+        run: nox -s venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.12"]
         go-version: ["1.20.12", "1.21.5"]
-        runs-on: [ubuntu-latest, macos-latest]
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +44,10 @@ jobs:
         if: matrix.runs-on == 'ubuntu-latest'
         run: sudo apt-get install gcc
 
+      - name: Install MinGW on Windows
+        if: matrix.runs-on == 'windows-latest'
+        run: choco install mingw
+
       - name: Install Python dependencies
         run: python -m pip install build virtualenv
 
@@ -51,12 +55,9 @@ jobs:
         run: |
           python -m build --wheel . --outdir dist/
 
-      - name: Create virtual environment
+      - name: Test entry points for package
         run: |
           python -m virtualenv venv
-
-      - name: Test entry points
-        run: |
           source venv/bin/activate
           python -m pip install dist/*.whl
           hugo version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    name: Wheels (Python ${{ matrix.python-version }} / Go ${{ matrix.go-version }} / ${{ matrix.runs-on }})
+    name: Wheels (${{ matrix.runs-on }} / Python ${{ matrix.python-version }} / Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
         run: |
           python -m build --wheel . --outdir dist/
 
-      - name: Test entry points for package
+      - name: Test entry points for package for macOS and Linux
+        if: matrix.runs-on != 'windows-latest'
         run: |
           python -m virtualenv venv
           source venv/bin/activate
@@ -63,3 +64,12 @@ jobs:
           hugo version
           hugo env --logLevel debug
 
+      - name: Test entry points for package for Windows
+        if: matrix.runs-on == 'windows-latest'
+        shell: bash
+        run: |
+          python -m virtualenv venv
+          venv\Scripts\activate
+          python -m pip install dist\*.whl
+          hugo version
+          hugo env --logLevel debug

--- a/noxfile.py
+++ b/noxfile.py
@@ -76,3 +76,12 @@ def release(session: nox.Session) -> None:
 
     session.install("build")
     session.run("python", "-m", "build")
+
+
+@nox.session(name="venv")
+def venv(session: nox.Session) -> None:
+    """Create a virtual environment and install wheels from the dist/ folder into it."""
+    for file in DIR.joinpath("dist").glob("*.whl"):
+        session.install(file)
+    session.run("hugo", "version")
+    session.run("hugo", "env", "--logLevel", "debug")

--- a/python_hugo/__init__.py
+++ b/python_hugo/__init__.py
@@ -19,6 +19,8 @@ FILE_EXT = ".exe" if sys.platform == "win32" else ""
 # On installing from a wheel, the binary is in the venv/binaries, but the package
 # is in venv/lib/python3.X/site-packages, so we need to go up two directories and
 # then down into binaries
+# Note: on Windows, this is venv\Lib\site-packages (instead of venv/lib/python3.X/site-packages)
+# therefore we need to go up to the venv directory and then down into the data files
 try:
     hugo_executable = os.path.join(
         os.path.dirname(__file__),
@@ -28,24 +30,38 @@ try:
     if not os.path.exists(hugo_executable):
         raise FileNotFoundError
 except FileNotFoundError:
-    hugo_executable = os.path.join(
-        # Go up into the venv directory and down into the data files
-        os.path.dirname(
+    if sys.platform == "win32":
+        PATH_TO_SEARCH = os.path.join(
             os.path.dirname(
                 os.path.dirname(
-            os.path.dirname(
-                os.path.dirname(__file__)
+                    os.path.dirname(
+                        os.path.dirname(__file__)
                     )
                 )
+            ),
+            "binaries"
+            ) # four times instead of five
+    else:
+        # five times instead of four
+        PATH_TO_SEARCH = os.path.join(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.dirname(
+                            os.path.dirname(__file__)
+                        )
+                    )
+                )
+            ),
+            "binaries"
             )
-        ),
-        "binaries",
-        f"hugo-{HUGO_VERSION}" + FILE_EXT,
-    )
+
+    # Go up into the venv directory and down into the data files
+    hugo_executable = os.path.join(PATH_TO_SEARCH, f"hugo-{HUGO_VERSION}" + FILE_EXT)
     if not os.path.exists(hugo_executable):
-        raise FileNotFoundError
+        raise FileNotFoundError from None
 except Exception as e:
-    print(f"Error: {e}")
+    sys.exit(f"Error: {e}")
 
 def __call():
     """

--- a/python_hugo/__init__.py
+++ b/python_hugo/__init__.py
@@ -11,7 +11,8 @@ import sys
 
 import importlib.metadata
 
-hugo_version = importlib.metadata.version("python-hugo")
+HUGO_VERSION = importlib.metadata.version("python-hugo")
+FILE_EXT = ".exe" if sys.platform == "win32" else ""
 
 # On editable and source installs, we keep binaries in the package directory
 # for ease of use. On wheel installs, we keep them in the venv/binaries directory.
@@ -22,7 +23,7 @@ try:
     hugo_executable = os.path.join(
         os.path.dirname(__file__),
         "binaries",
-        f"hugo-{hugo_version}"
+        f"hugo-{HUGO_VERSION}" + FILE_EXT,
     )
     if not os.path.exists(hugo_executable):
         raise FileNotFoundError
@@ -39,7 +40,7 @@ except FileNotFoundError:
             )
         ),
         "binaries",
-        f"hugo-{hugo_version}",
+        f"hugo-{HUGO_VERSION}" + FILE_EXT,
     )
     if not os.path.exists(hugo_executable):
         raise FileNotFoundError

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@ HUGO_RELEASE = (
 # We will point the build command to that location to build Hugo from source
 HUGO_CACHE_DIR = pooch.os_cache(".python_hugo")
 HUGO_SHA256 = "e374effe369c340d8085060e6bb45337eabf64cfe075295432ecafd6d033eb8b"
-# Path where the Hugo binary will be placed and copied from
-HUGO_BIN = os.path.join(os.environ.get("HOME"), "go")
 FILE_EXT = ".exe" if sys.platform == "win32" else ""
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,15 +54,9 @@ class HugoBuilder(build_ext):
         with tarfile.open(hugo_targz) as tar:
             tar.extractall(path=HUGO_CACHE_DIR)
 
-        os.environ["CGO_ENABLED"] = "1"
-
-        if sys.platform != "win32":
-            os.environ["GOPATH"] = os.path.join(os.environ.get("HOME"), "go")
-        else:
-            os.environ["GOPATH"] = os.path.join(os.environ.get("USERPROFILE"), "go")
-
-        # The binary is put into GOBIN, which is set to the package directory (src/python_hugo/binaries)
+        # The binary is put into GOBIN, which is set to the package directory (python_hugo/binaries)
         # for use in editable mode. The binary is copied into the wheel afterwards
+        os.environ["CGO_ENABLED"] = "1"
         os.environ["GOBIN"] = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "python_hugo", "binaries"
         )


### PR DESCRIPTION
The compiler used here is MinGW, the same as [what Hugo uses](https://github.com/gohugoio/hugo/blob/master/.github/workflows/test.yml). The file extension for executables on Windows is `.exe` so the binary is detected as such using a `FILE_EXT` constant.