### PR TITLE
Add tests against macOS M-series runners for PRs and wheel builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -244,7 +244,7 @@ jobs:
     strategy:
       fail-fast: false
     name: macOS wheels (arm64)
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:
@@ -268,9 +268,6 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_ARCHS_MACOS: arm64
-          # These are needed to build arm64 binaries on x86_64 macOS
-          CIBW_ENVIRONMENT_MACOS: >
-            GOARCH="arm64"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
           CIBW_TEST_COMMAND: >
             hugo version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ./hugo_cache/
-          key: ${{ runner.os }}-hugo-${{ steps.setup-go.outputs.go-version }}
+          key: ${{ matrix.runs-on }}-hugo-${{ steps.setup-go.outputs.go-version }}
 
       - name: Install Python dependencies
         run: python -m pip install build virtualenv nox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        runs-on: [ubuntu-latest, macos-latest, macos-14, windows-latest]
+        exclude:
+          - python-version: "3.8"
+            runs-on: macos-14
+          - python-version: "3.9"
+            runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This will now help test the M-series wheels when they are built. All Python versions have been added to the testing matrix.