### PR TITLE
Experimental cross-compilation to arm64 via Zig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   style:
-    name: Lint
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
@@ -75,6 +75,49 @@ jobs:
 
       - name: Test entry points for package
         run: nox -s venv
+
+  experimental:
+    needs: [style]
+    name: ubuntu-${{ matrix.architecture }}-python-${{ matrix.python-version }}
+    # TODO: try for Windows arm64 too?
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture: [arm64]
+        python-version: [3.8, 3.12, 3.13]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11      # v4.1.1
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Set up Go toolchain
+        id: setup-go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491  # v5.0.0
+        with:
+          go-version: "1.22.1"
+          cache: false
+          check-latest: true
+
+      - uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d  # v2.2.0
+        with:
+          version: 0.11.0
+
+      - name: Install Python dependencies
+        run: python -m pip install build virtualenv nox
+
+      - name: Build binary distribution (wheel)
+        # Cross-compile for arm64 target via Zig toolchain
+        env:
+          GOARCH: arm64
+          # We are on ubuntu amd64, so set target as arm64
+          CC: zig cc -target aarch64-linux-gnu
+          CXX: zig c++ -target aarch64-linux-gnu
+
+        run: |
+          python -m build --wheel . --outdir wheelhouse/
+
 
   inspect_distributions:
     needs: [style]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,20 @@ jobs:
 
   experimental:
     needs: [style]
-    name: ubuntu-${{ matrix.architecture }}-python-${{ matrix.python-version }}
-    # TODO: try for Windows arm64 too?
-    runs-on: ubuntu-latest
+    name: ${{ matrix.runs-on }}-${{ matrix.architecture }}-python-${{ matrix.python-version }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
+      fail-fast: false
       matrix:
+        runs-on: [ubuntu-latest, windows-latest]
         architecture: [arm64]
         python-version: [3.8, 3.12, 3.13]
+        # Test just one Python version on Windows
+        exclude:
+          - python-version: "3.8"
+            runs-on: windows-latest
+          - python-version: "3.13"
+            runs-on: windows-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11      # v4.1.1
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
@@ -105,19 +112,44 @@ jobs:
           version: 0.11.0
 
       - name: Install Python dependencies
-        run: python -m pip install build virtualenv nox
+        run: python -m pip install build virtualenv nox auditwheel
 
-      - name: Build binary distribution (wheel)
+      - name: Build binary distribution (wheel) on Linux
+        if: matrix.runs-on == 'ubuntu-latest'
         # Cross-compile for arm64 target via Zig toolchain
         env:
           GOARCH: arm64
           # We are on ubuntu amd64, so set target as arm64
           CC: zig cc -target aarch64-linux-gnu
           CXX: zig c++ -target aarch64-linux-gnu
-
         run: |
-          python -m build --wheel . --outdir wheelhouse/
+          python -m build --wheel . --outdir dist/
+        # can't repair arm64 wheels on Linux x86_64
+        # auditwheel repair --plat manylinux_2_28_aarch64 -w wheelhouse/ dist/*.whl
 
+      - name: Build binary distribution (wheel) on Windows
+        if: matrix.runs-on == 'windows-latest'
+        # We need to use cibuildwheel because it has experimental support for cross-compiling
+        # and setup-python does not have arm64 support on Windows right now
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce  # v2.17.0
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+        # Cross-compile for arm64 target via Zig toolchain
+        env:
+          GOARCH: arm64
+          # We are on Windows amd64, so set target as arm64
+          CC: zig cc -target aarch64-windows-gnu
+          CXX: zig c++ -target aarch64-windows-gnu
+          CIBW_SKIP: "pp* *musllinux*"
+          CIBW_BUILD: "cp312-*"
+          CIBW_ARCHS_WINDOWS: ARM64
+
+      - name: Upload artifacts for debugging
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3  # v4.3.1
+        with:
+            name: wheels_${{ matrix.runs-on }}_${{ matrix.architecture }}_py${{ matrix.python-version }}
+            path: ./wheelhouse/*.whl
 
   inspect_distributions:
     needs: [style]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           - python-version: "3.13"
             runs-on: windows-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11      # v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5.0.0
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
   experimental:
     needs: [style]
     name: ${{ matrix.runs-on }}-${{ matrix.architecture }}-python-${{ matrix.python-version }}
+    env:
+      CIBW_BUILD_VERBOSITY: 2
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,13 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest, windows-latest]
-        architecture: [arm64]
+        architecture: [arm64, i686]
         python-version: [3.8, 3.12, 3.13]
-        # Test just one Python version on Windows
+        # Exclude i686 on Linux for all Python versions
+        # Test just one Python version on Windows for now
         exclude:
+          - runs-on: ubuntu-latest
+            architecture: i686
           - python-version: "3.8"
             runs-on: windows-latest
           - python-version: "3.13"
@@ -123,14 +126,14 @@ jobs:
           CC: zig cc -target aarch64-linux-gnu
           CXX: zig c++ -target aarch64-linux-gnu
         run: |
-          python -m build --wheel . --outdir dist/
-        # can't repair arm64 wheels on Linux x86_64
+          python -m build --wheel . --outdir wheelhouse/
+        # can't repair arm64 wheels on Linux x86_64 right now
         # auditwheel repair --plat manylinux_2_28_aarch64 -w wheelhouse/ dist/*.whl
 
-      - name: Build binary distribution (wheel) on Windows
-        if: matrix.runs-on == 'windows-latest'
+      - name: Build binary distribution (wheel) on Windows (arm64)
+        if: matrix.runs-on == 'windows-latest' && matrix.architecture == 'arm64'
         # We need to use cibuildwheel because it has experimental support for cross-compiling
-        # and setup-python does not have arm64 support on Windows right now
+        # to arm64 and setup-python does not have arm64 support on Windows right now
         uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce  # v2.17.0
         with:
           package-dir: .
@@ -141,9 +144,28 @@ jobs:
           # We are on Windows amd64, so set target as arm64
           CC: zig cc -target aarch64-windows-gnu
           CXX: zig c++ -target aarch64-windows-gnu
-          CIBW_SKIP: "pp* *musllinux*"
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS_WINDOWS: ARM64
+          CIBW_TEST_SKIP: "*-win_arm64"
+
+        # Note: cibuildwheel will manage installing 32-bit Python on Windows. We
+        # do not need to do that manually unless we use setup-python instead.
+      - name: Build binary distribution (wheel) on Windows (i686)
+        if: matrix.runs-on == 'windows-latest' && matrix.architecture == 'i686'
+        uses: pypa/cibuildwheel@8d945475ac4b1aac4ae08b2fd27db9917158b6ce  # v2.17.0
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+        # Cross-compile for i686 target via Zig toolchain
+        env:
+          GOARCH: 386
+          CC: zig cc -target x86-windows-gnu
+          CXX: zig c++ -target x86-windows-gnu
+          CIBW_BUILD: "cp312-*"
+          CIBW_ARCHS_WINDOWS: x86
+          CIBW_TEST_COMMAND: >
+            hugo version
+            hugo env --logLevel debug
 
       - name: Upload artifacts for debugging
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3  # v4.3.1

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 Binaries for the **extended version** of the Hugo static site generator, installable via `pip`
 
-This package provides wheels for [Hugo](https://gohugo.io/) so that it can be used with `pip` on macOS, Linux, and Windows; for all Python 3 versions.
+This project provides wheels for [Hugo](https://gohugo.io/) so that it can be used with `pip` on macOS, Linux, and Windows; for all Python 3 versions.
 
 > [!NOTE]
 > Only the latest, stable, and to-be EOL Python versions are tested regularly. If you encounter any issues with the package on a specific Python version, please feel free to [open an issue](https://github.com/agriyakhetarpal/hugo-python-distributions/issues/new).
@@ -41,7 +41,7 @@ This package provides wheels for [Hugo](https://gohugo.io/) so that it can be us
 
 ## What version of `hugo` do I install?
 
-This package, `hugo` is versioned alongside the Hugo releases and is aligned with the versioning of Hugo itself, which uses `SemVer` – but is likely versioned according to [0ver](https://0ver.org/) software standards based on their [versioning history](https://github.com/gohugoio/hugo/releases).
+This project, `hugo` is versioned alongside the Hugo releases and is aligned with the versioning of Hugo itself, which uses `SemVer` – but is likely versioned according to [0ver](https://0ver.org/) software standards based on their [versioning history](https://github.com/gohugoio/hugo/releases).
 
 Binaries for `hugo` through these wheels are available for Hugo versions **0.121.2** and above, through PyPI or through releases on GitHubr. If you need an older version of `hugo` that is not available through this package, please consider using the [official Hugo binaries](https://github.com/gohugoio/hugo/releases).
 
@@ -114,24 +114,24 @@ For more information on using Hugo and its command-line interface, please refer 
 
 A subset of the platforms supported by Hugo itself are supported by these wheels for `hugo` via `hugo-python-distributions`. The plan is to support as many platforms as possible with Python wheels and platform tags. Please refer to the following table for a list of supported platforms and architectures:
 
-| Platform | Architecture    | Supported                       |
+| Platform | Architecture    | Support                         |
 | -------- | --------------- | ------------------------------- |
 | macOS    | x86_64 (Intel)  | ✅                              |
 | macOS    | arm64 (Silicon) | ✅                              |
 | Linux    | amd64           | ✅                              |
 | Linux    | arm64           | ✅                              |
 | Windows  | x86_64          | ✅                              |
-| Windows  | arm64           | 💡 Probable[^3]                 |
-| Windows  | i686            | ❌ Will not receive support[^1] |
+| Windows  | arm64           | 💡 Experimental support [^1]    |
+| Windows  | x86             | 💡 Experimental support [^1]    |
 | DragonFlyBSD | amd64       | ❌ Will not receive support[^2] |
 | FreeBSD  | amd64           | ❌ Will not receive support[^2] |
 | OpenBSD  | amd64           | ❌ Will not receive support[^2] |
 | NetBSD   | amd64           | ❌ Will not receive support[^2] |
 | Solaris  | amd64           | ❌ Will not receive support[^2] |
 
-[^1]: Windows 32-bit support is possible to include, but hasn't been included due to the diminishing popularity of i686 instruction set-based systems and the lack of resources to test and build for it. If you need support for Windows 32-bit, please consider either using the official Hugo binaries or compiling from [HugoReleaser](https://github.com/gohugoio/hugoreleaser).
+[^1]: Support for 32-bit (i686) and arm64 architectures on Windows is made possible through the use of the [Zig compiler toolchain](https://ziglang.org/) that uses the LLVM ecosystem. These wheels are experimental owing to the use of `cibuildwheel` and cross-compilation and may not be stable or reliable for all use cases, and are not officially supported by the Hugo project at this time. Please refer to the [Building from source](#building-from-source) section for more information on how to build Hugo for these platforms and architectures, since these wheels are not currently pushed to PyPI for general availability – however, they are tested regularly in CI. If you need support for these platforms, please consider building from source or through a CI provider.
+
 [^2]: Support for these platforms is not possible to include because of i. the lack of resources to test and build for them and ii. the lack of support for these platform specifications in Python packaging standards and tooling. If you need support for these platforms, please consider downloading the [official Hugo binaries](https://github.com/gohugoio/hugo/releases)
-[^3]: Support for Windows ARM64 is possible to include, but `cibuildwheel` support for it is currently experimental. Hugo does not officially support Windows ARM64 at the moment, but it should be possible to build from source for it and can receive support in the future through this package.
 
 ### Building from source
 
@@ -161,9 +161,17 @@ pip install .                 # regular installation
 #### Cross-compiling for different architectures
 
 > [!NOTE]
-> This functionality is implemented just for macOS at the moment, but it can be extended to other platforms as well in the near future.
+> Cross-compilation is experimental and may not be stable or reliable for all use cases. If you encounter any issues with cross-compilation, please feel free to [open an issue](https://github.com/agriyakhetarpal/hugo-python-distributions/issues/new).
 
-This package is capable of cross-compiling Hugo binaries for the same platform but different architectures and it can be used as follows. Cross-compilation is provided and tested on macOS for the `arm64` and `amd64` architectures via the Xcode toolchain.
+This project is capable of cross-compiling Hugo binaries for various platforms and architectures and it can be used as follows. Cross-compilation is provided for the following platforms:
+
+1. macOS for the `arm64` and `amd64` architectures via the Xcode toolchain,
+2. Linux for the `arm64` and `amd64` architectures via the Zig toolchain, and
+3. Windows for the `arm64`, and `x86` architectures via the Zig toolchain.
+
+Please refer to the examples below for more information on how to cross-compile Hugo for different architectures:
+
+##### macOS
 
 Say, on an Intel-based (x86_64) macOS machine:
 
@@ -172,22 +180,81 @@ export GOARCH="arm64"
 pip install .  # or pip install -e .
 ```
 
-This will build a macOS arm64 binary distribution of Hugo that can be used on Apple Silicon-based (arm64) macOS machines. To build a binary distribution for the _target_ Intel-based (x86_64) macOS platform on the _host_ Apple Silicon-based (arm64) macOS machine, you can use the following command:
+This will build a macOS `arm64` binary distribution of Hugo that can be used on Apple Silicon-based (`arm64`) macOS machines. To build a binary distribution for the _target_ Intel-based (`x86_64`) macOS platform on the _host_ Apple Silicon-based (`arm64`) macOS machine, you can use the following command:
 
 ```bash
 export GOARCH="amd64"
 pip install .  # or pip install -e .
 ```
 
+##### Linux
+
+First, install [Zig](https://ziglang.org/download/) on your Linux machine, and set these environment variables prior to installing the package:
+
+Say, on an `amd64` Linux machine:
+
+```bash
+export CC="zig cc -target aarch64-linux-gnu"
+export CXX="zig c++ -target aarch64-linux-gnu"
+export GOARCH="arm64"
+pip install .  # or pip install -e .
+```
+
+will cross-compile a Linux arm64 binary distribution of Hugo that can be used on the targeted arm64 Linux machines. To build a binary distribution for the _target_ `amd64` Linux platform on the _host_ `arm64` Linux machine, set the targets differently:
+
+```bash
+export CC="zig cc -target x86_64-linux-gnu"
+export CXX="zig c++ -target x86_64-linux-gnu"
+export GOARCH="amd64"
+pip install .  # or pip install -e .
+```
+
+This creates dynamic linkage for the built Hugo binary with a system-provided GLIBC. If you wish to statically link the binary with MUSL, change the `CC` and `CXX` environment variables as follows:
+
+```bash
+export CC="zig cc -target x86_64-linux-musl"
+export CXX="zig c++ -target x86_64-linux-musl"
+```
+
+Linkage against MUSL is not tested in CI at this time, but it should work in theory. The official Hugo binaries do not link against MUSL for a variety of reasons including but not limited to the size of the binary and the popularity of the GLIBC C standard library and its conventions.
+
+##### Windows
+
+First, install [Zig](https://ziglang.org/download/) on your Windows machine, and set these environment variables prior to installing the package:
+
+Say, on an `amd64` Windows machine:
+
+```bash
+set CC="zig cc -target aarch64-windows-gnu"
+set CXX="zig c++ -target aarch64-windows-gnu"
+set GOARCH="arm64"
+pip install .  # or pip install -e .
+```
+
+will cross-compile a Windows `arm64` binary distribution of Hugo that can be used on the targeted `arm64` Windows machines (note the use of `set` instead of `export` on Windows), and so on for the `x86` architecture:
+
+```bash
+set CC="zig cc -target x86-windows-gnu"
+set CXX="zig c++ -target x86-windows-gnu"
+set GOARCH="386"
+pip install .  # or pip install -e .
+```
+
+For a list of supported distributions for Go, please run the `go tool dist list` command on your system. For a list of supported targets for Zig, please refer to the [Zig documentation](https://ziglang.org/documentation/) for more information or run the `zig targets` command on your system.
+
+> [!NOTE]
+> Cross-compilation for a target platform and architecture from a different host platform and architecture should be possible, but remains largely untested at this time.
+
+
 ### Background
 
 Binaries for the Hugo static site generator are available for download from the [Hugo releases page](https://github.com/gohugoio/hugo/releases). These binaries have to be downloaded and placed in an appropriate location on the system manually and the PATH environment variable has to be updated to include said location.
 
-This package provides wheels for Hugo to be used with `pip` on macOS, Linux, and Windows. This allows Hugo to be installed and used in a virtual environment, which allows multiple versions of Hugo to be installed and used side-by-side in different virtual environments, where Hugo can be used as a command-line tool (a Python API is not provided at this time given the lack of such a demand for it).
+This project provides wheels for Hugo to be used with `pip` on macOS, Linux, and Windows. This allows Hugo to be installed and used in a virtual environment, which allows multiple versions of Hugo to be installed and used side-by-side in different virtual environments, where Hugo can be used as a command-line tool (a Python API is not provided at this time given the lack of such a demand for it).
 
 #### Use cases
 
-This package is designed to be used in the following scenarios:
+This project is designed to be used in the following scenarios:
 
 - You want to use Hugo as a command-line tool, but you don't want it to be installed globally on your system or do not have the necessary permissions to do so.
 - You cannot or do not want to use the official Hugo binaries
@@ -200,8 +267,8 @@ This package is designed to be used in the following scenarios:
 
 #### (Known) limitations
 
-- It is difficult to provide wheels for all platforms and architectures (see [Supported platforms](#supported-platforms)), so this package only provides wheels for the most common ones—those supported by Python platform tags, packaging standards and tooling—it is not reasonable to do so and provide releases for other platforms owing to the limited resources available on CI systems, in this case, GitHub Actions runners. For extra platforms and architectures, please refer to the [Building from source](#building-from-source) section or consider using the [official Hugo binaries](https://github.com/gohugoio/hugo/releases) for your purpose.
-- This package does not provide a Python API for Hugo, it just wraps its own command-line interface. The packaging infrastructure for this Python package is not designed to provide a Python API for Hugo, and it is not the goal of this package to provide one. If you need a Python API for Hugo, please refer to the [Hugo documentation](https://gohugo.io/documentation/) for further resources on how to use Hugo programmatically as needed.
+- It is difficult to provide wheels for all platforms and architectures (see [Supported platforms](#supported-platforms)), so this project only provides wheels for the most common ones—those supported by Python platform tags, packaging standards and tooling—it is not reasonable to do so and provide releases for other platforms owing to the limited resources available on CI systems, in this case, GitHub Actions runners. For extra platforms and architectures, please refer to the [Building from source](#building-from-source) section or consider using the [official Hugo binaries](https://github.com/gohugoio/hugo/releases) for your purpose.
+- This project does not provide a Python API for Hugo, it just wraps its own command-line interface. The packaging infrastructure for this Python package is not designed to provide a Python API for Hugo, and it is not the goal of this project to provide one. If you need a Python API for Hugo, please refer to the [Hugo documentation](https://gohugo.io/documentation/) for further resources on how to use Hugo programmatically as needed.
 
 ### Licensing
 

--- a/hugo/cli.py
+++ b/hugo/cli.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from os import execvp, path
 from platform import machine
 from subprocess import check_call
-from sys import argv
+from sys import argv, maxsize
 from sys import platform as sysplatform
 
 with open(path.join(path.dirname(__file__), "VERSION")) as f:  # noqa: PTH123, PTH120, PTH118
@@ -30,7 +30,15 @@ HUGO_ARCH = {
     "arm64": "arm64",
     "AMD64": "amd64",
     "aarch64": "arm64",
+    "x86": "386",
 }[machine()]
+
+# platform.machine returns AMD64 on Windows because the architecture is
+# 64-bit (even if one is running a 32-bit Python interpreter). Therefore
+# we use sys. maxsize to handle this special case on Windows
+
+if not (maxsize > 2**32) and sysplatform == "win32":
+    HUGO_ARCH = "386"
 
 
 @lru_cache(maxsize=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "pooch", "tqdm", "wheel==0.42.0"]
+requires = ["setuptools>=64", "pooch", "tqdm", "wheel==0.42.0", "ziglang>=0.11.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools>=64", "pooch", "tqdm", "wheel==0.42.0", "ziglang>=0.11.0"]
+requires = [
+  "setuptools>=64",
+  "pooch",
+  "tqdm",
+  "wheel==0.42.0",
+  # "ziglang>=0.11.0"
+  ]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -360,6 +360,12 @@ class HugoWheel(bdist_wheel):
                 # replace amd64 in plat with arm64
                 platform_tag = platform_tag.replace("amd64", "arm64")
 
+            # Similarly, ensure correct platform tags for 32-bit Windows
+            if os.environ.get("GOARCH") == "386":
+                # A 32-bit Windows looks like cmake-3.28.4-py3-none-win32.whl
+                # So we need to replace win_amd64 with win32
+                platform_tag = platform_tag.replace("win_amd64", "win32")
+
         return python_tag, abi_tag, platform_tag
 
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ HUGO_ARCH = {
     "arm64": "arm64",
     "AMD64": "amd64",
     "aarch64": "arm64",
+    "x86": "386",
 }[platform.machine()]
 
 # Name of the Hugo binary that will be built

--- a/setup.py
+++ b/setup.py
@@ -175,12 +175,12 @@ class HugoBuilder(build_ext):
 
         # Zig compiler is required for cross-compilation on Linux and Windows, but we will
         # check for this only if we are cross-compiling and not on macOS (where Xcode is used).
-        if (os.environ.get("GOARCH") != self.hugo_arch) and (sys.platform != "darwin"):
-            try:
-                subprocess.check_call([sys.executable, "-m", "ziglang", "version"])
-            except OSError as err:
-                error_message = "Zig compiler not found. Please install Zig from https://ziglang.org/download/ or your package manager."
-                raise OSError(error_message) from err
+        # if (os.environ.get("GOARCH") != self.hugo_arch) and (sys.platform != "darwin"):
+        #     try:
+        #         subprocess.check_call([sys.executable, "-m", "ziglang", "version"])
+        #     except OSError as err:
+        #         error_message = "Zig compiler not found. Please install Zig from https://ziglang.org/download/ or your package manager."
+        #         raise OSError(error_message) from err
 
         # GCC/Clang is required for building Hugo because CGO is enabled
         try:


### PR DESCRIPTION
Closes #16 via usage of the `zig` toolchain, to compile:

1. to Linux arm64 from Linux amd64,
2. to Windows arm64 from Windows amd64, and
3. to Windows i686/x86 natively via 32-bit Python interpreters provided by `cibuildwheel`