### PR TITLE
Do not rely on `pooch` and `tdqm` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
   "setuptools>=64",
-  "pooch",
-  "tqdm",
   "wheel==0.42.0",
   # "ziglang>=0.11.0"
   ]

--- a/setup.py
+++ b/setup.py
@@ -187,19 +187,19 @@ class HugoBuilder(build_ext):
         ldflags = [
             f"-s -w -X github.com/gohugoio/hugo/common/hugo.vendorInfo={HUGO_VENDOR_NAME}"
         ]
-        if not (Path(HUGO_CACHE_DIR).resolve() / f"hugo-{HUGO_VERSION}").exists():
-            subprocess.check_call(
-                [
-                    "git",
-                    "clone",
-                    "https://github.com/gohugoio/hugo.git",
-                    "--depth=1",
-                    "--single-branch",
-                    "--branch",
-                    f"v{HUGO_VERSION}",
-                    Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}",
-                ]
-            )
+        # Clone the Hugo repository at each invocation to ensure a fresh, non-corrupt source.
+        subprocess.check_call(
+            [
+                "git",
+                "clone",
+                "https://github.com/gohugoio/hugo.git",
+                "--depth=1",
+                "--single-branch",
+                "--branch",
+                f"v{HUGO_VERSION}",
+                Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}",
+            ]
+        )
         subprocess.check_call(
             [
                 "go",
@@ -324,7 +324,7 @@ class HugoWheel(bdist_wheel):
     """
     A customised wheel build command that sets the platform tags to accommodate
     the varieties of the GOARCH and GOOS environment variables when cross-compiling
-    the Hugo binary. Currently used for macOS arm64 and macOS x86_64.
+    the Hugo binary with any available cross-compilation toolchain.
     """
 
     def initialize_options(self):
@@ -405,7 +405,7 @@ class HugoWheel(bdist_wheel):
             Path(__file__).parent
             / "hugo"
             / "binaries"
-            / f"{os.environ.get('GOOS', HUGO_PLATFORM)}_{os.environ.get('GOARCH', HUGO_ARCH)}{FILE_EXT}"
+            / f"hugo-{HUGO_VERSION}-{os.environ.get('GOOS', HUGO_PLATFORM)}-{os.environ.get('GOARCH', HUGO_ARCH)}{FILE_EXT}"
         )
 
         # if the binary does not exist, then we need to build it, so invoke

--- a/setup.py
+++ b/setup.py
@@ -140,11 +140,11 @@ class HugoBuilder(build_ext):
         #
         # Once built this the files are cached into GOPATH for future use
 
-        # Delete hugo_cache/bin/ + git clone + files inside, if left over from a previous build
+        # Delete hugo_cache/bin/ + files inside, if left over from a previous build
         shutil.rmtree(Path(HUGO_CACHE_DIR).resolve() / "bin", ignore_errors=True)
-        shutil.rmtree(
-            Path(HUGO_CACHE_DIR).resolve() / f"hugo-{HUGO_VERSION}", ignore_errors=True
-        )
+        # shutil.rmtree(
+        #     Path(HUGO_CACHE_DIR).resolve() / f"hugo-{HUGO_VERSION}", ignore_errors=True
+        # )
 
         # Check for compilers, toolchains, etc. and raise helpful errors if they
         # are not found. These are essentially smoke tests to ensure that the
@@ -187,19 +187,21 @@ class HugoBuilder(build_ext):
         ldflags = [
             f"-s -w -X github.com/gohugoio/hugo/common/hugo.vendorInfo={HUGO_VENDOR_NAME}"
         ]
-        # Clone the Hugo repository at each invocation to ensure a fresh, non-corrupt source.
-        subprocess.check_call(
-            [
-                "git",
-                "clone",
-                "https://github.com/gohugoio/hugo.git",
-                "--depth=1",
-                "--single-branch",
-                "--branch",
-                f"v{HUGO_VERSION}",
-                Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}",
-            ]
-        )
+
+        if not (Path(HUGO_CACHE_DIR).resolve() / f"hugo-{HUGO_VERSION}").exists():
+            subprocess.check_call(
+                [
+                    "git",
+                    "clone",
+                    "https://github.com/gohugoio/hugo.git",
+                    "--depth=1",
+                    "--single-branch",
+                    "--branch",
+                    f"v{HUGO_VERSION}",
+                    Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}",
+                ]
+            )
+
         subprocess.check_call(
             [
                 "go",

--- a/setup.py
+++ b/setup.py
@@ -187,19 +187,19 @@ class HugoBuilder(build_ext):
         ldflags = [
             f"-s -w -X github.com/gohugoio/hugo/common/hugo.vendorInfo={HUGO_VENDOR_NAME}"
         ]
-
-        subprocess.check_call(
-            [
-                "git",
-                "clone",
-                "https://github.com/gohugoio/hugo.git",
-                "--depth=1",
-                "--single-branch",
-                "--branch",
-                f"v{HUGO_VERSION}",
-                Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}",
-            ]
-        )
+        if not (Path(HUGO_CACHE_DIR).resolve() / f"hugo-{HUGO_VERSION}").exists():
+            subprocess.check_call(
+                [
+                    "git",
+                    "clone",
+                    "https://github.com/gohugoio/hugo.git",
+                    "--depth=1",
+                    "--single-branch",
+                    "--branch",
+                    f"v{HUGO_VERSION}",
+                    Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}",
+                ]
+            )
         subprocess.check_call(
             [
                 "go",


### PR DESCRIPTION
This is also slightly related to #35 but I can't get it working completely.

Before (`hugo` with `pipx` with the latest release at the time of writing):

```
Running Hugo 0.125.0 via hugo-python-distributions at /Users/agriyakhetarpal/Library/Caches/pipx/5fd9955d5bcbcca/lib/python3.11/site-packages/hugo/binaries/hugo-0.125.0-darwin-arm64
hugo v0.125.0-ba08e3ab8bf65735497f5697dc80ce62daebac92+extended darwin/arm64 BuildDate=2024-04-16T16:25:07Z VendorInfo=hugo-python-distributions
```

After (on editable install)

```
Running Hugo 0.125.2 via hugo-python-distributions at /Users/agriyakhetarpal/Desktop/hugo-python-distributions/hugo/binaries/hugo-0.125.2-darwin-arm64
hugo v0.125.2+extended darwin/arm64 BuildDate=2024-04-21T15:49:28Z VendorInfo=hugo-python-distributions
```

i.e., we still don't have the hash but at least it's a step forward to the upstream output and also the package builds much faster on a cache hit!
