### PR TITLE
🧑‍💻 Add `withdeploy` build tag and bump to Hugo 0.137.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 </div>
 
-Binaries for the **extended version** of the Hugo static site generator, installable via `pip`
+Binaries for the **`extended` + `withdeploy` edition** of the Hugo static site generator, installable via `pip`
 
 This project provides wheels for [Hugo](https://gohugo.io/) so that it can be used with `pip` on macOS, Linux, and Windows; for Python 3.9 and later.
 
@@ -141,7 +141,7 @@ A subset of the platforms supported by Hugo itself are supported by these wheels
 
 ### Building from source
 
-Building the extended version of Hugo from source requires the following dependencies:
+Building the extended + withdeploy edition of Hugo from source requires the following dependencies:
 
 - The [Go](https://go.dev/doc/install) toolchain
 - The [Git](https://git-scm.com/downloads) version control system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 maintainers = [
   { name = "Agriya Khetarpal", email = "agriyakhetarpal@outlook.com" },
 ]
-description = "Binaries for the Hugo static site generator, installable with pip"
+description = "Binaries for the 'extended + withdeploy' edition of the Hugo static site generator, installable with pip"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = "~=3.9"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.build_py import build_py
 
 # ------ Hugo build configuration and constants ------------------------------------
 
-HUGO_VERSION = "0.136.5"
+HUGO_VERSION = "0.137.0"
 # The Go toolchain will download the tarball into the hugo_cache/ directory.
 # We will point the build command to that location to build Hugo from source
 HUGO_CACHE_DIR = "hugo_cache"
@@ -286,7 +286,7 @@ class HugoBuilder(build_ext):
                 "-ldflags",
                 " ".join(ldflags),
                 "-tags",
-                "extended,nodeploy",
+                "extended,withdeploy",
             ],
             cwd=(Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}").resolve(),
         )

--- a/setup.py
+++ b/setup.py
@@ -286,7 +286,7 @@ class HugoBuilder(build_ext):
                 "-ldflags",
                 " ".join(ldflags),
                 "-tags",
-                "extended",
+                "extended,nodeploy",
             ],
             cwd=(Path(HUGO_CACHE_DIR) / f"hugo-{HUGO_VERSION}").resolve(),
         )


### PR DESCRIPTION
~~Reduces the wheel size by up to 25%. I need to investigate whether this is employed by HugoReleaser and also various packagers and channels (Fedora does it, but are there any others?). Also, I need to investigate the limitations of this build tag.~~

~~Homebrew doesn't do it: https://github.com/Homebrew/homebrew-core/blob/755b5cf34822621965034223b863e63fa57a7d29/Formula/h/hugo.rb~~

> [!IMPORTANT]
> Updated below, please see https://github.com/agriyakhetarpal/hugo-python-distributions/pull/90#issuecomment-2455264627