### PR TITLE
Use `-trimpath` to strip local path information for smaller executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ class HugoBuilder(build_ext):
             [
                 "go",
                 "install",
+                "-trimpath",
                 "-v",
                 "-ldflags",
                 " ".join(ldflags),


### PR DESCRIPTION
Based on guidance provided in https://github.com/gohugoio/hugo/issues/12406. Reduces around ~2427 extra strings locally, which amount to ~1.2 megabytes or so – it isn't much because the dependency information is still there, but it's a step in the right direction along with #90.