### PR TITLE
Set macOS compatibility >=10.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,22 +118,22 @@ For more information on using Hugo and its command-line interface, please refer 
 
 A subset of the platforms supported by Hugo itself are supported by these wheels for `hugo` via `hugo-python-distributions`. The plan is to support as many platforms as possible with Python wheels and platform tags. Please refer to the following table for a list of supported platforms and architectures:
 
-| Platform     | Architecture    | Support                             |
-| ------------ | --------------- | ----------------------------------- |
-| macOS        | x86_64 (Intel)  | ✅ macOS 10.9 (Mavericks) and later |
-| macOS        | arm64 (Silicon) | ✅ macOS 11.0 (Big Sur) and later   |
-| Linux        | amd64           | ✅ glibc 2.24 and later             |
-| Linux        | arm64           | ✅ glibc 2.24 and later             |
-| Linux        | s390x           | ✅ glibc 2.17 and later             |
-| Linux        | ppc64le         | ✅ glibc 2.17 and later             |
-| Windows      | x86_64          | ✅                                  |
-| Windows      | arm64           | ✅💡 Experimental support [^1]      |
-| Windows      | x86             | ✅💡 Experimental support [^1]      |
-| DragonFlyBSD | amd64           | ❌ Will not receive support[^2]     |
-| FreeBSD      | amd64           | ❌ Will not receive support[^2]     |
-| OpenBSD      | amd64           | ❌ Will not receive support[^2]     |
-| NetBSD       | amd64           | ❌ Will not receive support[^2]     |
-| Solaris      | amd64           | ❌ Will not receive support[^2]     |
+| Platform     | Architecture    | Support                                |
+| ------------ | --------------- | -------------------------------------- |
+| macOS        | x86_64 (Intel)  | ✅ macOS 10.13 (High Sierra) and later |
+| macOS        | arm64 (Silicon) | ✅ macOS 11.0 (Big Sur) and later      |
+| Linux        | amd64           | ✅ glibc 2.24 and later                |
+| Linux        | arm64           | ✅ glibc 2.24 and later                |
+| Linux        | s390x           | ✅ glibc 2.17 and later                |
+| Linux        | ppc64le         | ✅ glibc 2.17 and later                |
+| Windows      | x86_64          | ✅                                     |
+| Windows      | arm64           | ✅💡 Experimental support [^1]         |
+| Windows      | x86             | ✅💡 Experimental support [^1]         |
+| DragonFlyBSD | amd64           | ❌ Will not receive support[^2]        |
+| FreeBSD      | amd64           | ❌ Will not receive support[^2]        |
+| OpenBSD      | amd64           | ❌ Will not receive support[^2]        |
+| NetBSD       | amd64           | ❌ Will not receive support[^2]        |
+| Solaris      | amd64           | ❌ Will not receive support[^2]        |
 
 [^1]: Support for 32-bit (i686) and arm64 architectures on Windows is made possible through the use of the [Zig compiler toolchain](https://ziglang.org/) that uses the LLVM ecosystem. These wheels are experimental owing to the use of cross-compilation and may not be stable or reliable for all use cases, and are not officially supported by the Hugo project at this time. Hence, while these are published to PyPI for general availability, they are considered experimental. Please refer to the [Building from source](#building-from-source) section for more information on how to build Hugo for these platforms and architectures locally. If you need official support for these platforms or face any bugs, please consider contacting the Hugo authors by [https://github.com/gohugoio/hugo/issues/new](opening an issue).
 

--- a/setup.py
+++ b/setup.py
@@ -403,7 +403,7 @@ class HugoWheel(bdist_wheel):
         # Cross-compiling to macOS or on macOS via the Zig or Xcode toolchains
         # ====================================================================
         # Also, ensure correct platform tags for macOS arm64 and macOS x86_64
-        # since macOS 3.12 Python GH Actionsrunners are mislabelling the platform
+        # since macOS 3.12 Python GH Actions runners are mislabelling the platform
         # tag to be universal2, see: https://github.com/pypa/wheel/issues/573
         # Also, let cibuildwheel handle the platform tags if it is being used,
         # since that is where we won't cross-compile at all but use the native
@@ -414,7 +414,7 @@ class HugoWheel(bdist_wheel):
             if os.environ.get("GOARCH") == "arm64":
                 platform_tag = "macosx_11_0_arm64"
             elif os.environ.get("GOARCH") == "amd64":
-                platform_tag = "macosx_10_9_x86_64"
+                platform_tag = "macosx_10_13_x86_64"
 
         return python_tag, abi_tag, platform_tag
 


### PR DESCRIPTION
11.0 is EoL, CPython 3.12.6 and later are using 10.13 now, and 10.9 is very rarely used, according to download statistics.