### PR TITLE
Enable cross-compilation across platforms and architectures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=70.1.1",
-  # "ziglang>=0.13.0"
+  "ziglang>=0.13.0"
   ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
We are now at a stage where we can allow this, i.e., to let a Windows arm64 user compile to, say, a Linux ppc64le target if they wish to. Nothing was stopping them from doing this earlier if they wanted – this lets the wheels include the binary within them when cross-compiling with Zig, therefore the wheels are now valid.