### PR TITLE
Stop pre-commit from pushing to PRs for autofixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ ci:
   autoupdate_commit_msg: "📈 Update versions for pre-commit hooks"
   autofix_commit_msg: "🪩 Automated fixes from https://pre-commit.ci"
   autoupdate_schedule: "weekly"
+  autofix_prs: false
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
It's not that useful from a security standpoint, and it also causes the dreaded feedback loop where an automated commit emerges on remote branches where I'm actively working and I suddenly need to pull in new changes before I can push my commits. Just asking the bot to fix the failures in a comment is so much better.