### PR TITLE
Install into `py.get_install_dir()` and set `ninja` as a build-time dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,7 +110,7 @@ custom_target(
     '--goarch',  goarch,
   ],
   install : true,
-  install_dir : get_option('datadir') / 'hugo' / 'binaries',
+  install_dir : py.get_install_dir() / 'hugo' / 'binaries',
   install_tag : 'python-runtime',
   build_by_default : true,
   console : true,

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,8 @@ def venv(session: nox.Session) -> None:
 @nox.session(default=False, reuse_venv=True)
 def editable(session: nox.Session) -> None:
     """Smoke test console and module entry points from an editable install."""
-    session.install("meson-python==0.19.0", "ziglang==0.15.2", "ninja")
+    build_deps = nox.project.load_toml("pyproject.toml")["build-system"]["requires"]
+    session.install(*build_deps)
     session.install("--no-build-isolation", "-ve", ".")
     session.run("python", "-m", "hugo", "version")
     session.run("hugo", "version")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
   "meson-python==0.19.0",
+  # newer ninjas aren't available on PyPI:
+  # https://github.com/scikit-build/ninja-python-distributions/issues/308
+  "ninja==1.13.0",
   "ziglang==0.16.0",
   "go-bin==1.26.3",
 ]

--- a/src/hugo/cli.py
+++ b/src/hugo/cli.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-import sysconfig
 from contextlib import nullcontext
 from pathlib import Path, PurePosixPath
 from sys import platform as sysplatform
@@ -17,7 +16,7 @@ from sys import platform as sysplatform
 from hugo._version import HUGO_VERSION
 
 HUGO_EXECUTABLE = "hugo.exe" if sysplatform == "win32" else "hugo"
-HUGO_BINARY_PATH = Path("hugo", "binaries", HUGO_EXECUTABLE)
+HUGO_BINARY_PATH = Path("binaries", HUGO_EXECUTABLE)
 
 
 def _editable_hugo_executable() -> Path | None:
@@ -47,8 +46,7 @@ def _editable_hugo_executable() -> Path | None:
 
 
 def _hugo_executable():
-    data_path = Path(sysconfig.get_path("data"))
-    binary = data_path / HUGO_BINARY_PATH
+    binary = Path(__file__).parent / HUGO_BINARY_PATH
     if binary.is_file():
         return nullcontext(binary)
 


### PR DESCRIPTION
Closes #314 by moving the Hugo binary back into `binaries` inside the wheel's installed files because `sysconfig.get_path("data")` on a user installation installs the binaries into an awkward location