### PR TITLE
Install executable to `platlib` and override `mesonpy._WheelBuilder._has_extension_modules`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,12 +5,14 @@ project(
   default_options : ['warning_level=0'],
 )
 
-# Setting `pure: true` routes the Python package to purelib, so platlib stays
-# empty. The bundled Hugo executable is installed under datadir and the marker
-# file below keeps the wheel tag at py3-none-<platform> instead of a
-# Python-version-specific ABI tag.
+# Setting `pure: false` routes both Python sources and the Hugo executable to
+# platlib, keeping them in the same site-packages subtree. This satisfies
+# auditwheel (ELF binaries must not be in purelib) and lets cli.py locate the
+# binary via Path(__file__).parent regardless of install scheme.
+# The marker file below keeps the wheel tag at py3-none-<platform> instead of
+# a Python-version-specific ABI tag.
 # See _has_extension_modules and _pure in mesonpy/__init__.py
-py = import('python').find_installation(pure: true)
+py = import('python').find_installation(pure: false)
 
 go  = find_program('go',  required: true)
 git = find_program('git', required: true)

--- a/scripts/hugo_meson_python_wrapper.py
+++ b/scripts/hugo_meson_python_wrapper.py
@@ -97,6 +97,20 @@ def _maybe_set_host_platform(config_settings: dict[str, Any] | None) -> None:
     )  # TODO: drop this hack/use of private API
 
 
+def _force_py3_none_tag() -> None:
+    """Force py3-none-<platform> instead of cp<XY>-cp<XY>-<platform>.
+
+    With pure: false, meson-python assumes every file in {platlib} is a CPython
+    extension module and applies a Python-version-specific ABI tag. The Hugo
+    binary is a Go executable that runs under any Python version, so we patch
+    _has_extension_modules to always return False, and that causes meson-python
+    to fall through to the py3-none-<platform> branch in its tag property.
+    TODO: drop this hack/use of public API if meson-python someday exposes a way
+    to opt out of the CPython ABI tag for non-extension platlib content.
+    """
+    mesonpy._WheelBuilder._has_extension_modules = property(lambda _: False)
+
+
 # Unchanged meson-python PEP 517 entry points below
 
 
@@ -106,6 +120,7 @@ def build_wheel(
     metadata_directory: str | None = None,
 ) -> str:
     _maybe_set_host_platform(config_settings)
+    _force_py3_none_tag()
     return mesonpy.build_wheel(wheel_directory, config_settings, metadata_directory)
 
 
@@ -115,6 +130,7 @@ def build_editable(
     metadata_directory: str | None = None,
 ) -> str:
     _maybe_set_host_platform(config_settings)
+    _force_py3_none_tag()
     return mesonpy.build_editable(wheel_directory, config_settings, metadata_directory)
 
 


### PR DESCRIPTION
- [x] CI
- [x] CD: https://github.com/agriyakhetarpal/hugo-python-distributions/actions/runs/26729930087
- [x] Wheel tag is correct

Closes #314 