### PR TITLE
Use PEP 517 hooks better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,21 +52,6 @@ jobs:
           python-version: "3.14"
           activate-environment: true
 
-      - name: Get Go version from pyproject.toml
-        id: go-version
-        shell: python
-        run: |
-          import re, os
-          version = re.search(r'go-bin==([0-9.]+)', open('pyproject.toml').read()).group(1)
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f'version={version}\n')
-
-      - name: Restore Hugo builder cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/hugo-go
-          key: editable-install-hugo-${{ runner.os }}-${{ steps.go-version.outputs.version }}
-
       - name: Install Python dependencies
         run: uv pip install nox[uv]
 
@@ -102,24 +87,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
 
-      - name: Get Go version from pyproject.toml
-        id: go-version
-        shell: python
-        run: |
-          import re, os
-          version = re.search(r'go-bin==([0-9.]+)', open('pyproject.toml').read()).group(1)
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f'version={version}\n')
-
       - name: Install MinGW on Windows
         if: matrix.runs-on == 'windows-latest'
         run: choco install mingw
-
-      - name: Restore Hugo builder cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/hugo-go
-          key: ${{ matrix.runs-on }}-hugo-${{ steps.go-version.outputs.version }}
 
       - name: Install Python dependencies
         run: uv pip install build virtualenv nox[uv]
@@ -163,21 +133,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true
-
-      - name: Get Go version from pyproject.toml
-        id: go-version
-        shell: python
-        run: |
-          import re, os
-          version = re.search(r'go-bin==([0-9.]+)', open('pyproject.toml').read()).group(1)
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f'version={version}\n')
-
-      - name: Restore Hugo builder cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/hugo-go
-          key: zig-${{ matrix.runs-on }}-${{ matrix.architecture}}-hugo-experimental-${{ steps.go-version.outputs.version }}
 
       - name: Install Python dependencies
         run: uv pip install build virtualenv nox auditwheel

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,25 +28,10 @@ jobs:
           fetch-depth: 0
           submodules: "recursive"
 
-      - name: Get Go version from pyproject.toml
-        id: go-version
-        shell: python
-        run: |
-          import re, os
-          version = re.search(r'go-bin==([0-9.]+)', open('pyproject.toml').read()).group(1)
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f'version={version}\n')
-
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
           activate-environment: true
-
-      - name: Restore Hugo builder cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./hugo_cache/
-          key: ubuntu-latest-hugo-${{ steps.go-version.outputs.version }}
 
       - name: Install Python dependencies
         run: uv pip install nox

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,9 @@ project(
 # See _has_extension_modules and _pure in mesonpy/__init__.py
 py = import('python').find_installation(pure: false)
 
-go  = find_program('go',  required: true)
+# sdist builds do not require a Go toolchain. It is only needed when compiling
+# the Hugo binary. We enforce it at wheel build time in build_hugo.py anyway.
+go  = find_program('go',  required: false)
 git = find_program('git', required: true)
 
 # Verify the hugo-src submodule tag matches the declared version at configure time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,6 @@ requires = [
   # newer ninjas aren't available on PyPI:
   # https://github.com/scikit-build/ninja-python-distributions/issues/308
   "ninja==1.13.0",
-  "ziglang==0.16.0",
-  "go-bin==1.26.3",
 ]
 build-backend = "hugo_meson_python_wrapper"
 backend-path = ["scripts"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,5 @@
 [build-system]
-requires = [
-  "meson-python==0.19.0",
-  # newer ninjas aren't available on PyPI:
-  # https://github.com/scikit-build/ninja-python-distributions/issues/308
-  "ninja==1.13.0",
-]
+requires = ["meson-python==0.19.0"]
 build-backend = "hugo_meson_python_wrapper"
 backend-path = ["scripts"]
 

--- a/scripts/hugo_meson_python_wrapper.py
+++ b/scripts/hugo_meson_python_wrapper.py
@@ -61,8 +61,8 @@ def _strip_quotes(string: str) -> str:
     return string.strip().strip("'\"")
 
 
-def _host_platform_tag(config_settings: dict[str, Any] | None) -> str | None:
-    """Return the target wheel platform tag from a Meson cross file, if any."""
+def _parse_cross_file(config_settings: dict[str, Any] | None) -> tuple[str, str] | None:
+    """Return (system, cpu_family) from a Meson cross file in config_settings, or None."""
     if not config_settings:
         return None
     setup_args = _flatten(config_settings.get("setup-args"))
@@ -82,7 +82,32 @@ def _host_platform_tag(config_settings: dict[str, Any] | None) -> str | None:
 
     system = _strip_quotes(cfg["host_machine"].get("system", ""))
     family = _strip_quotes(cfg["host_machine"].get("cpu_family", ""))
-    return PLATFORM_TAGS_MAP.get((system, family))
+    return (system, family) if system and family else None
+
+
+def _host_platform_tag(config_settings: dict[str, Any] | None) -> str | None:
+    """Return the target wheel platform tag from a Meson cross file, if any."""
+    host = _parse_cross_file(config_settings)
+    return None if host is None else PLATFORM_TAGS_MAP.get(host)
+
+
+def _needs_zig(config_settings: dict[str, Any] | None) -> bool:
+    """Return True if the Zig compiler is needed for this build.
+
+    We do `auto_use_zig = meson.is_cross_build() and host_sys != 'darwin'`.
+    It maps here. An explicit -Duse_zig=true/false in setup-args overrides
+    the auto logic.
+    """
+    host = _parse_cross_file(config_settings)
+    if host is None:
+        return False
+    setup_args = _flatten(config_settings.get("setup-args") if config_settings else [])
+    for arg in setup_args:
+        m = re.match(r"-Duse_zig=(true|false)$", arg)
+        if m:
+            return m.group(1) == "true"
+    system, _ = host
+    return system != "darwin"
 
 
 def _maybe_set_host_platform(config_settings: dict[str, Any] | None) -> None:
@@ -143,7 +168,11 @@ def build_sdist(
 def get_requires_for_build_wheel(
     config_settings: dict[str, Any] | None = None,
 ) -> list[str]:
-    return mesonpy.get_requires_for_build_wheel(config_settings)
+    reqs = list(mesonpy.get_requires_for_build_wheel(config_settings))
+    reqs.append("go-bin==1.26.3")
+    if _needs_zig(config_settings):
+        reqs.append("ziglang==0.16.0")
+    return reqs
 
 
 def get_requires_for_build_editable(

--- a/scripts/hugo_meson_python_wrapper.py
+++ b/scripts/hugo_meson_python_wrapper.py
@@ -178,7 +178,9 @@ def get_requires_for_build_wheel(
 def get_requires_for_build_editable(
     config_settings: dict[str, Any] | None = None,
 ) -> list[str]:
-    return mesonpy.get_requires_for_build_editable(config_settings)
+    reqs = list(mesonpy.get_requires_for_build_editable(config_settings))
+    reqs.append("go-bin==1.26.3")
+    return reqs
 
 
 def get_requires_for_build_sdist(


### PR DESCRIPTION
- Our static build-time dependencies can just have `meson-python`. `go-bin` is required only for wheel builds, so we can drop it from being required for sdist builds so that `meson sdist` and `meson setup` can pass with a toolchain. It's now defined via `get_requires_for_build_wheel` and `get_requires_for_build_editable` build backend hooks.
- `ziglang` is now injected only when a `--cross-file` is detected, i.e., it's not there when we are not cross-compiling.
- `ninja` is handled dynamically via meson-python's own hooks, so we don't need to bother about it.

Wheels:
- [x] https://github.com/agriyakhetarpal/hugo-python-distributions/actions/runs/27077087740