### PR TITLE
Use cibuildwheel v4.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,9 +10,6 @@ on:
 
 env:
   FORCE_COLOR: 3
-  CIBW_BUILD_FRONTEND: "build"
-  CIBW_BUILD: "cp314-*"
-  CIBW_SKIP: "pp* *musllinux*"
 
 permissions: {}
 
@@ -71,13 +68,6 @@ jobs:
         with:
           package-dir: .
           output-dir: wheelhouse
-        env:
-          CIBW_ARCHS_WINDOWS: AMD64
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -101,16 +91,8 @@ jobs:
         # We need to use cibuildwheel because it has experimental support for cross-compiling
         # to arm64 and setup-python does not have arm64 support on Windows right now
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
-        with:
-          package-dir: .
-          output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: ARM64
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-arm64.ini"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
-          CIBW_TEST_SKIP: "*-win_arm64"
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -121,7 +103,7 @@ jobs:
 
   windows_i686_wheels:
     name: i686-windows
-    runs-on: windows-2025
+    runs-on: windows-latest
     permissions:
       contents: read
     steps:
@@ -132,18 +114,8 @@ jobs:
 
       - name: Build binary distribution (wheel) on Windows (i686)
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
-        with:
-          package-dir: .
-          output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: x86
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-386.ini"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -167,11 +139,6 @@ jobs:
         with:
           package-dir: .
           output-dir: wheelhouse
-        env:
-          CIBW_ARCHS_LINUX: x86_64
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -195,11 +162,6 @@ jobs:
         with:
           package-dir: .
           output-dir: wheelhouse
-        env:
-          CIBW_ARCHS_LINUX: aarch64
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -229,15 +191,8 @@ jobs:
 
       - name: Build binary distribution (wheel) on Linux (s390x)
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
-        with:
-          package-dir: .
-          output-dir: wheelhouse
         env:
           CIBW_ARCHS_LINUX: s390x
-          CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/go_installed/go/bin
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -263,15 +218,8 @@ jobs:
 
       - name: Build binary distribution (wheel) on Linux (ppc64le)
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
-        with:
-          package-dir: .
-          output-dir: wheelhouse
         env:
           CIBW_ARCHS_LINUX: ppc64le
-          CIBW_ENVIRONMENT_LINUX: PATH=$PATH:$HOME/go_installed/go/bin
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -295,11 +243,6 @@ jobs:
         with:
           package-dir: .
           output-dir: wheelhouse
-        env:
-          CIBW_ARCHS_MACOS: x86_64
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -323,11 +266,6 @@ jobs:
         with:
           package-dir: .
           output-dir: wheelhouse
-        env:
-          CIBW_ARCHS_MACOS: arm64
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ on:
 env:
   FORCE_COLOR: 3
   CIBW_BUILD_FRONTEND: "build"
-  CIBW_BUILD: "cp312-*"
+  CIBW_BUILD: "cp314-*"
   CIBW_SKIP: "pp* *musllinux*"
 
 permissions: {}
@@ -96,13 +96,6 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Resolve Windows Meson cross file
-        id: meson-cross-file
-        shell: pwsh
-        run: |
-          $crossFile = (Resolve-Path (Join-Path $env:GITHUB_WORKSPACE 'meson_cross_files/windows-arm64.ini')).Path -replace '\\', '/'
-          "path=$crossFile" >> $env:GITHUB_OUTPUT
-
       - name: Build binary distribution (wheel) on Windows (arm64)
         # We need to use cibuildwheel because it has experimental support for cross-compiling
         # to arm64 and setup-python does not have arm64 support on Windows right now
@@ -111,10 +104,10 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp312-*"
+          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: ARM64
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file=${{ steps.meson-cross-file.outputs.path }}"
+          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-arm64.ini"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
           CIBW_TEST_SKIP: "*-win_arm64"
 
@@ -136,23 +129,16 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Resolve Windows Meson cross file
-        id: meson-cross-file
-        shell: pwsh
-        run: |
-          $crossFile = (Resolve-Path (Join-Path $env:GITHUB_WORKSPACE 'meson_cross_files/windows-386.ini')).Path -replace '\\', '/'
-          "path=$crossFile" >> $env:GITHUB_OUTPUT
-
       - name: Build binary distribution (wheel) on Windows (i686)
         uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp312-*"
+          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: x86
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file=${{ steps.meson-cross-file.outputs.path }}"
+          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-386.ini"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
           CIBW_TEST_COMMAND: |
             hugo version

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -260,10 +260,6 @@ jobs:
       - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
           platforms: all
-          # This should be temporary
-          # xref https://github.com/docker/setup-qemu-action/issues/188
-          # xref https://github.com/tonistiigi/binfmt/issues/215
-          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build binary distribution (wheel) on Linux (ppc64le)
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Install MinGW compiler(s)
         run: choco install mingw
 
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -107,7 +106,7 @@ jobs:
       - name: Build binary distribution (wheel) on Windows (arm64)
         # We need to use cibuildwheel because it has experimental support for cross-compiling
         # to arm64 and setup-python does not have arm64 support on Windows right now
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -145,7 +144,7 @@ jobs:
           "path=$crossFile" >> $env:GITHUB_OUTPUT
 
       - name: Build binary distribution (wheel) on Windows (i686)
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -177,7 +176,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -205,7 +204,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -242,7 +241,7 @@ jobs:
           image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build binary distribution (wheel) on Linux (s390x)
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -280,7 +279,7 @@ jobs:
           image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build binary distribution (wheel) on Linux (ppc64le)
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -309,7 +308,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -337,7 +336,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+      - uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Install MinGW compiler(s)
         run: choco install mingw
 
+      - name: Build binary distribution (wheel) on Windows (amd64)
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,17 @@ jobs:
 
       - name: Build binary distribution (wheel) on Linux
         if: matrix.runs-on == 'ubuntu-latest'
-        run: python -m build --wheel . --outdir wheelhouse -Csetup-args=--cross-file="{project}/meson_cross_files/linux-arm64.ini"
         # can't repair arm64 wheels on Linux x86_64 right now
         # auditwheel repair --plat manylinux_2_28_aarch64 -w wheelhouse/ dist/*.whl
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+        env:
+          CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.13' && '313' || '314' }}-*"
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_CONFIG_SETTINGS_LINUX: "setup-args=--cross-file={project}/meson_cross_files/linux-arm64.ini"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
 
       - name: Build binary distribution (wheel) on Windows (arm64)
         if: matrix.runs-on == 'windows-latest' && matrix.architecture == 'arm64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,20 +139,9 @@ jobs:
 
       - name: Build binary distribution (wheel) on Linux
         if: matrix.runs-on == 'ubuntu-latest'
-        run: python -m build --wheel . --outdir wheelhouse -Csetup-args=--cross-file="$GITHUB_WORKSPACE/meson_cross_files/linux-arm64.ini"
+        run: python -m build --wheel . --outdir wheelhouse -Csetup-args=--cross-file="{project}/meson_cross_files/linux-arm64.ini"
         # can't repair arm64 wheels on Linux x86_64 right now
         # auditwheel repair --plat manylinux_2_28_aarch64 -w wheelhouse/ dist/*.whl
-
-      - name: Resolve Windows Meson cross file
-        if: matrix.runs-on == 'windows-latest'
-        id: meson-cross-file
-        shell: pwsh
-        env:
-          MATRIX_ARCH: ${{ matrix.architecture }}
-        run: |
-          $crossFileName = if ($env:MATRIX_ARCH -eq 'arm64') { 'windows-arm64.ini' } else { 'windows-386.ini' }
-          $crossFile = (Resolve-Path (Join-Path $env:GITHUB_WORKSPACE "meson_cross_files/$crossFileName")).Path -replace '\\', '/'
-          "path=$crossFile" >> $env:GITHUB_OUTPUT
 
       - name: Build binary distribution (wheel) on Windows (arm64)
         if: matrix.runs-on == 'windows-latest' && matrix.architecture == 'arm64'
@@ -162,10 +151,10 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp312-*"
+          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: ARM64
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file=${{ steps.meson-cross-file.outputs.path }}"
+          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-arm64.ini"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
           CIBW_TEST_SKIP: "*-win_arm64"
 
@@ -178,10 +167,10 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp312-*"
+          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: x86
           CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file=${{ steps.meson-cross-file.outputs.path }}"
+          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-386.ini"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
           CIBW_TEST_COMMAND: |
             hugo version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Build binary distribution (wheel) on Windows (arm64)
         if: matrix.runs-on == 'windows-latest' && matrix.architecture == 'arm64'
         # TODO: FIXME: use windows-11-arm runners as they're available now, and drop this
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -173,7 +173,7 @@ jobs:
         # do not need to do that manually unless we use setup-python instead.
       - name: Build binary distribution (wheel) on Windows (i686)
         if: matrix.runs-on == 'windows-latest' && matrix.architecture == 'i686'
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         with:
           package-dir: .
           output-dir: wheelhouse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ concurrency:
 
 env:
   FORCE_COLOR: 3
-  CIBW_SKIP: "pp* *musllinux*"
-  CIBW_BUILD_FRONTEND: "build"
 
 permissions: {}
 
@@ -91,15 +89,7 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
         env:
-          # The wheel is py3-none, so building for the single matrix Python is
-          # enough to exercise the build on each interpreter. cibuildwheel picks
-          # each runner's native architecture automatically.
           CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.13' && '313' || '314' }}-*"
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
   # TODO: add aarch64 to x86_64 cross-compilation for Linux
   experimental:
@@ -140,8 +130,14 @@ jobs:
         env:
           CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.13' && '313' || '314' }}-*"
           CIBW_ARCHS_LINUX: x86_64
+          # This job lies about the arch (x86_64 container, aarch64 wheel via the
+          # cross file), so its build identifier collides with the native x86_64
+          # build and can't be selected in a pyproject override. Keep the cross
+          # settings here, and disable the global test-command and repair: the
+          # aarch64 wheel can neither run nor be repaired on x86_64.
           CIBW_CONFIG_SETTINGS_LINUX: "setup-args=--cross-file={project}/meson_cross_files/linux-arm64.ini"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
+          CIBW_TEST_COMMAND: ""
 
       - name: Build binary distribution (wheel) on Windows (arm64)
         if: matrix.runs-on == 'windows-latest' && matrix.architecture == 'arm64'
@@ -151,12 +147,7 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: ARM64
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-arm64.ini"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
-          CIBW_TEST_SKIP: "*-win_arm64"
 
         # Note: cibuildwheel will manage installing 32-bit Python on Windows. We
         # do not need to do that manually unless we use setup-python instead.
@@ -167,14 +158,7 @@ jobs:
           package-dir: .
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "cp314-*"
           CIBW_ARCHS_WINDOWS: x86
-          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-          CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--cross-file={project}/meson_cross_files/windows-386.ini"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
-          CIBW_TEST_COMMAND: |
-            hugo version
-            hugo env --logLevel debug
 
       - name: Upload artifacts for debugging
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,24 +82,24 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-          activate-environment: true
-
-      - name: Install MinGW on Windows
+      - name: Install MinGW compiler(s) on Windows
         if: matrix.runs-on == 'windows-latest'
         run: choco install mingw
 
-      - name: Install Python dependencies
-        run: uv pip install build virtualenv nox[uv]
-
-      - name: Build binary distribution (wheel)
-        run: |
-          python -m build --wheel . --outdir wheelhouse/
-
-      - name: Test entry points for package
-        run: nox -s venv
+      - uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+        env:
+          # The wheel is py3-none, so building for the single matrix Python is
+          # enough to exercise the build on each interpreter. cibuildwheel picks
+          # each runner's native architecture automatically.
+          CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.13' && '313' || '314' }}-*"
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: |
+            hugo version
+            hugo env --logLevel debug
 
   # TODO: add aarch64 to x86_64 cross-compilation for Linux
   experimental:
@@ -128,14 +128,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-          activate-environment: true
-
-      - name: Install Python dependencies
-        run: uv pip install build virtualenv nox auditwheel
 
       - name: Build binary distribution (wheel) on Linux
         if: matrix.runs-on == 'ubuntu-latest'

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,17 +24,6 @@ def lint(session: nox.Session) -> None:
     session.run("prek", "-a", *session.posargs)
 
 
-@nox.session(name="venv", reuse_venv=True)
-def venv(session: nox.Session) -> None:
-    """Create a virtual environment and install wheels from a specified folder into it."""
-    folder = "dist" if session.interactive else "wheelhouse"
-    session.log(f"Installing wheels from {folder}")
-    for file in DIR.joinpath(folder).glob("*.whl"):
-        session.install(file)
-        session.run("hugo", "version")
-        session.run("hugo", "env", "--logLevel", "debug")
-
-
 @nox.session(default=False, reuse_venv=True)
 def editable(session: nox.Session) -> None:
     """Smoke test console and module entry points from an editable install."""
@@ -43,17 +32,6 @@ def editable(session: nox.Session) -> None:
     session.install("--no-build-isolation", "-ve", ".")
     session.run("python", "-m", "hugo", "version")
     session.run("hugo", "version")
-
-
-def _get_version(session: nox.Session) -> str:
-    """Extract version from session posargs or meson.build."""
-    if session.posargs:
-        return session.posargs[0].lstrip("v")
-    content = (DIR / "meson.build").read_text()
-    match = re.search(r"version\s*:\s*'([0-9.]+)'", content)
-    if not match:
-        session.error("Could not determine version. Pass it as: nox -s tag -- 0.157.0")
-    return match.group(1)
 
 
 @nox.session(default=False, reuse_venv=True)
@@ -68,6 +46,17 @@ def docs(session: nox.Session) -> None:
         session.run("hugo", "server", "--source", str(DOCS_DIR))
     else:
         session.run("hugo", "--minify", "--source", str(DOCS_DIR))
+
+
+def _get_version(session: nox.Session) -> str:
+    """Extract version from session posargs or meson.build."""
+    if session.posargs:
+        return session.posargs[0].lstrip("v")
+    content = (DIR / "meson.build").read_text()
+    match = re.search(r"version\s*:\s*'([0-9.]+)'", content)
+    if not match:
+        session.error("Could not determine version. Pass it as: nox -s tag -- 0.157.0")
+    return match.group(1)
 
 
 @nox.session(default=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ allow-windows-internal-shared-libs = true
 # but since we are shipping a none-any wheel this doesn't matter for local
 # builds as we don't want to build multiple wheels
 build = "cp314-*"
+skip = "*musllinux*"
 test-command = """
 hugo version
 hugo env --logLevel debug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,14 +78,18 @@ test-skip = "*-win_arm64"
 archs = ["AMD64"]
 
 # cross-compile the Windows arm64 wheel with the matching Meson cross file
+# Switch back to {project} once https://github.com/pypa/cibuildwheel/pull/2934
+# makes it to a release
 [[tool.cibuildwheel.overrides]]
 select = "*-win_arm64"
-config-settings = { setup-args = "--cross-file={project}/meson_cross_files/windows-arm64.ini" }
+config-settings = { setup-args = "--cross-file={package}/meson_cross_files/windows-arm64.ini" }
 
 # cross-compile the Windows 32-bit (x86) wheel with the matching Meson cross file
 [[tool.cibuildwheel.overrides]]
 select = "*-win32"
-config-settings = { setup-args = "--cross-file={project}/meson_cross_files/windows-386.ini" }
+# Switch back to {project} once https://github.com/pypa/cibuildwheel/pull/2934
+# makes it to a release
+config-settings = { setup-args = "--cross-file={package}/meson_cross_files/windows-386.ini" }
 
 [tool.ruff]
 src = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,33 @@ hugo = "hugo.cli:__call"
 [tool.meson-python]
 allow-windows-internal-shared-libs = true
 
+[tool.cibuildwheel]
+# CI overrides CIBW_BUILD to also exercise the build on other interpreters
+# but since we are shipping a none-any wheel this doesn't matter for local
+# builds as we don't want to build multiple wheels
+build = "cp314-*"
+test-command = """
+hugo version
+hugo env --logLevel debug
+"""
+# arm64 wheels are cross-compiled from the x86_64 runner and cannot run there
+test-skip = "*-win_arm64"
+
+[tool.cibuildwheel.windows]
+# auto would also build 32-bit x86 on a 64-bit runner. That target is
+# cross-compiled in its own job, so let's keep native Windows builds as AMD64 only.
+archs = ["AMD64"]
+
+# cross-compile the Windows arm64 wheel with the matching Meson cross file
+[[tool.cibuildwheel.overrides]]
+select = "*-win_arm64"
+config-settings = { setup-args = "--cross-file={project}/meson_cross_files/windows-arm64.ini" }
+
+# cross-compile the Windows 32-bit (x86) wheel with the matching Meson cross file
+[[tool.cibuildwheel.overrides]]
+select = "*-win32"
+config-settings = { setup-args = "--cross-file={project}/meson_cross_files/windows-386.ini" }
+
 [tool.ruff]
 src = ["src"]
 lint.extend-select = [


### PR DESCRIPTION
- We can now use config settings placeholders
- Resolving Meson cross-file paths on Windows is no longer needed
- Build on Python 3.14
- All cibuildwheel configuration moved to pyproject.toml
- No need for delvewheel to be manually installed

To check:
- [x] CI passes
- [ ] CD passes: https://github.com/agriyakhetarpal/hugo-python-distributions/actions/runs/28334892012