### PR TITLE
Download 32-bit ARM Go toolchain for piwheels

### DIFF
--- a/scripts/build_hugo.py
+++ b/scripts/build_hugo.py
@@ -18,6 +18,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from piwheels_go_toolchain import download_go_toolchain, is_32bit_arm_linux
+
 HUGO_VENDOR_NAME = "hugo-python-distributions"
 
 
@@ -91,10 +93,10 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def check_dependencies(use_zig: bool) -> None:
+def check_dependencies(go_binary: str, use_zig: bool) -> None:
     try:
         subprocess.check_call(
-            [_GO_BINARY, "version"],
+            [go_binary, "version"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -249,10 +251,17 @@ def main() -> int:
     cache.mkdir(parents=True, exist_ok=True)
     shutil.rmtree(cache / "bin", ignore_errors=True)
 
-    check_dependencies(use_zig)
+    go_binary, go_goroot = _GO_BINARY, _GO_GOROOT
+    if is_32bit_arm_linux() and go_binary == "go":
+        # It is impossible for go-bin to ship armv6l/armv7l wheels as it
+        # just bundles the downloaded Go toolchain, so we need to download
+        # it ourselves for piwheels.
+        go_binary, go_goroot = download_go_toolchain(cache)
 
-    if _GO_GOROOT:
-        os.environ.setdefault("GOROOT", _GO_GOROOT)
+    check_dependencies(go_binary, use_zig)
+
+    if go_goroot:
+        os.environ.setdefault("GOROOT", go_goroot)
 
     os.environ["CGO_ENABLED"] = "1"
     os.environ["GO111MODULE"] = "on"
@@ -282,7 +291,7 @@ def main() -> int:
     with SubmoduleVcsSwap(hugo_src):
         subprocess.check_call(
             [
-                _GO_BINARY,
+                go_binary,
                 "install",
                 "-trimpath",
                 "-v",

--- a/scripts/hugo_meson_python_wrapper.py
+++ b/scripts/hugo_meson_python_wrapper.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 import mesonpy
+from piwheels_go_toolchain import GO_VERSION, is_32bit_arm_linux
 
 # (host_machine.system, host_machine.cpu_family) -> _PYTHON_HOST_PLATFORM
 PLATFORM_TAGS_MAP: dict[tuple[str, str], str] = {
@@ -169,7 +170,11 @@ def get_requires_for_build_wheel(
     config_settings: dict[str, Any] | None = None,
 ) -> list[str]:
     reqs = list(mesonpy.get_requires_for_build_wheel(config_settings))
-    reqs.append("go-bin==1.26.3")
+    # It is impossible for go-bin to ship armv6l/armv7l wheels as it
+    # just bundles the downloaded Go toolchain, so we need to download
+    # it ourselves for piwheels instead of relying on go-bin.
+    if not is_32bit_arm_linux():
+        reqs.append(f"go-bin=={GO_VERSION}")
     if _needs_zig(config_settings):
         reqs.append("ziglang==0.16.0")
     return reqs
@@ -179,7 +184,8 @@ def get_requires_for_build_editable(
     config_settings: dict[str, Any] | None = None,
 ) -> list[str]:
     reqs = list(mesonpy.get_requires_for_build_editable(config_settings))
-    reqs.append("go-bin==1.26.3")
+    if not is_32bit_arm_linux():
+        reqs.append(f"go-bin=={GO_VERSION}")
     return reqs
 
 

--- a/scripts/piwheels_go_toolchain.py
+++ b/scripts/piwheels_go_toolchain.py
@@ -1,0 +1,53 @@
+"""
+Shared helpers for obtaining a Go toolchain on 32-bit ARM Linux
+on piwheels.
+
+The go-bin PyPI package that we use as a build-time dependency does
+not publish wheels or an sdist for armv6l/armv7l (piwheels), and thus
+breaks builds on that platform. On that one platform, we can bypass
+and download the official go.dev toolchain archive directly instead.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import platform
+import shutil
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+
+# Keep in sync with the go-bin pins in hugo_meson_python_wrapper.py
+GO_VERSION = "1.26.3"
+GO_LINUX_ARM_SHA256 = "d44133d4c66b1451a1e247da26db7716f76a081c0169a75e6c84e1871e394320"
+
+GO_LINUX_ARM_FILENAME = f"go{GO_VERSION}.linux-armv6l.tar.gz"
+GO_LINUX_ARM_URL = f"https://go.dev/dl/{GO_LINUX_ARM_FILENAME}"
+
+
+def is_32bit_arm_linux() -> bool:
+    return sys.platform == "linux" and platform.machine() in ("armv6l", "armv7l")
+
+
+def download_go_toolchain(dest_dir: Path) -> tuple[str, str]:
+    """Download and extract the official Go toolchain for 32-bit ARM Linux on piwheels."""
+    goroot = dest_dir / "go"
+    shutil.rmtree(goroot, ignore_errors=True)
+
+    archive_path = dest_dir / GO_LINUX_ARM_FILENAME
+    urllib.request.urlretrieve(GO_LINUX_ARM_URL, archive_path)
+
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    if digest != GO_LINUX_ARM_SHA256:
+        msg = (
+            f"checksum mismatch for {GO_LINUX_ARM_FILENAME}: "
+            f"expected {GO_LINUX_ARM_SHA256}, got {digest}"
+        )
+        raise RuntimeError(msg)
+
+    with tarfile.open(archive_path) as tar:
+        tar.extractall(dest_dir, filter="data")
+    archive_path.unlink()
+
+    return str(goroot / "bin" / "go"), str(goroot)


### PR DESCRIPTION
`go-bin` cannot publish wheels or an sdist for 32-bit ARM Linux. So on piwheels' builders, we fail immediately: https://www.piwheels.org/project/hugo/. The system Go on Raspberry Pi OS isn't a fallback either, since recent Hugo versions need Go 1.26 (https://github.com/gohugoio/hugo/pull/15002) and Debian's packaged Go is much older.

So we download the official Go toolchain from https://go.dev for 32-bit Raspberry Pi builders. Everywhere else, behaviour is unchanged.